### PR TITLE
Use content type header for a request

### DIFF
--- a/src/Flow/ETL/Adapter/Http/RequestEntriesFactory.php
+++ b/src/Flow/ETL/Adapter/Http/RequestEntriesFactory.php
@@ -27,7 +27,7 @@ final class RequestEntriesFactory
     {
         $requestType = 'html';
 
-        foreach ($request->getHeader('Accept') as $header) {
+        foreach ($request->getHeader('Content-Type') as $header) {
             if (\strpos('application/json', $header) !== false) {
                 $requestType = 'json';
             }

--- a/src/Flow/ETL/Adapter/Http/RequestEntriesFactory.php
+++ b/src/Flow/ETL/Adapter/Http/RequestEntriesFactory.php
@@ -27,12 +27,21 @@ final class RequestEntriesFactory
     {
         $requestType = 'html';
 
-        foreach ($request->getHeader('Content-Type') as $header) {
-            if (\strpos('application/json', $header) !== false) {
-                $requestType = 'json';
+        if ($request->hasHeader('Content-Type')) {
+            foreach ($request->getHeader('Content-Type') as $header) {
+                if (\strpos('application/json', $header) !== false) {
+                    $requestType = 'json';
+                }
+            }
+        } else {
+            foreach ($request->getHeader('Accept') as $header) {
+                if (\strpos('application/json', $header) !== false) {
+                    $requestType = 'json';
+                }
             }
         }
 
+        $requestBodyEntry = new Row\Entry\NullEntry('request_body');
         $requestBody = $request->getBody();
 
         if ($requestBody->isReadable()) {
@@ -46,23 +55,23 @@ final class RequestEntriesFactory
                 $requestBody->seek(0);
             }
 
-            switch ($requestType) {
-                case 'json':
-                    if (\class_exists('Flow\ETL\Row\Entry\JsonEntry')) {
-                        $requestBodyEntry = new Row\Entry\JsonEntry('request_body', \json_decode($requestBodyContent, true, 512, JSON_THROW_ON_ERROR));
-                    } else {
+            if (!empty($requestBodyContent)) {
+                switch ($requestType) {
+                    case 'json':
+                        if (\class_exists('Flow\ETL\Row\Entry\JsonEntry')) {
+                            $requestBodyEntry = new Row\Entry\JsonEntry('request_body', \json_decode($requestBodyContent, true, 512, JSON_THROW_ON_ERROR));
+                        } else {
+                            $requestBodyEntry = new Row\Entry\StringEntry('request_body', $requestBodyContent);
+                        }
+
+                        break;
+
+                    default:
                         $requestBodyEntry = new Row\Entry\StringEntry('request_body', $requestBodyContent);
-                    }
 
-                    break;
-
-                default:
-                    $requestBodyEntry = new Row\Entry\StringEntry('request_body', $requestBodyContent);
-
-                    break;
+                        break;
+                }
             }
-        } else {
-            $requestBodyEntry = new Row\Entry\NullEntry('request_body');
         }
 
         return new Row\Entries(

--- a/tests/Flow/ETL/Tests/Unit/RequestEntriesFactoryTest.php
+++ b/tests/Flow/ETL/Tests/Unit/RequestEntriesFactoryTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Tests\Unit;
+
+use Flow\ETL\Adapter\Http\RequestEntriesFactory;
+use Flow\ETL\Row\Entry\JsonEntry;
+use Flow\ETL\Row\Entry\NullEntry;
+use Flow\ETL\Row\Entry\StringEntry;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+
+final class RequestEntriesFactoryTest extends TestCase
+{
+    /**
+     * @dataProvider requests
+     */
+    public function test_uses_expected_entry_for_request_body(string $expectedRequestBodyEntryClass, RequestInterface $request) : void
+    {
+        $entryFactory = new RequestEntriesFactory();
+
+        $this->assertInstanceOf(
+            $expectedRequestBodyEntryClass,
+            $entryFactory->create($request)->get('request_body')
+        );
+    }
+
+    public function requests() : \Generator
+    {
+        $messageFactory = new Psr17Factory();
+        $request = $messageFactory
+            ->createRequest('POST', 'https://flow-php.io/example')
+            ->withBody($messageFactory->createStream(\json_encode(['status' => 'success'])));
+
+        yield 'uses StringEntry for request body when neither Accept and Content-Type header is present' => [
+            StringEntry::class,
+            $request,
+        ];
+
+        yield 'uses JsonEntry for request body when Content-Type header is application/json' => [
+            JsonEntry::class,
+            $request
+                ->withHeader('Content-Type', 'application/json')
+                ->withHeader('Accept', 'application/xml'),
+        ];
+
+        yield 'uses JsonEntry for request body when Accept header is application/json' => [
+            JsonEntry::class,
+            $request->withHeader('Accept', 'application/json'),
+        ];
+
+        yield 'NullEntry when request body is empty' => [
+            NullEntry::class,
+            $messageFactory
+                ->createRequest('POST', 'https://flow-php.io/example')
+                ->withHeader('Content-Type', 'application/json'),
+        ];
+    }
+}

--- a/tests/Flow/ETL/Tests/Unit/RequestEntriesFactoryTest.php
+++ b/tests/Flow/ETL/Tests/Unit/RequestEntriesFactoryTest.php
@@ -51,7 +51,7 @@ final class RequestEntriesFactoryTest extends TestCase
             $request->withHeader('Accept', 'application/json'),
         ];
 
-        yield 'NullEntry when request body is empty' => [
+        yield 'uses NullEntry for request body when when request body is empty' => [
             NullEntry::class,
             $messageFactory
                 ->createRequest('POST', 'https://flow-php.io/example')


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
<li>Use content type header for a request  entires factory</li> 
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Current implementation use `Accept` header which defines the response format, but we want to determine the request format. To do that we should rely on `Content-Type` header not the `Accept` header. When I send an empty request with `Accept` header equals to `application/json` then I receive an error:

```
vendor/flow-php/etl-adapter-http/src/Flow/ETL/Adapter/Http/RequestEntriesFactory.php(52): json_decode()
```
https://github.com/flow-php/etl-adapter-http/blob/1.x/src/Flow/ETL/Adapter/Http/RequestEntriesFactory.php#L52
